### PR TITLE
Update doc.

### DIFF
--- a/doc/pydocstring.txt
+++ b/doc/pydocstring.txt
@@ -124,7 +124,7 @@ TEMPLATE					*pydocstring-vim-template*
 
 If you don't like default docstring, You can modify docstring template.
 >
-  let g:template_vim_template_dir = '/path/to/your/template/directory'
+  let g:pydocstring_templates_dir = '/path/to/your/template/directory/'
 <
 - comment.txt
   Comment.


### PR DESCRIPTION
Does not work if trailing slash is omitted, so it's nice to point it out.
And there was a variable name mistmatch:
     template_vim_template_dir
should be:
     pydocstring_templates_dir
